### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,6 +141,8 @@ jobs:
     needs: [test, publish]
     if: failure()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Notify failure
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/peanutbother/serini/security/code-scanning/3](https://github.com/peanutbother/serini/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `Notify on Failure` job, explicitly limiting the `GITHUB_TOKEN` permissions to `contents: read`. This ensures that the job has only the minimal permissions required to execute its steps, reducing the risk of unintended repository modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
