### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,8 @@ jobs:
     name: Publish to Crates.io
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/peanutbother/serini/security/code-scanning/2](https://github.com/peanutbother/serini/security/code-scanning/2)

To fix the issue, we will add an explicit `permissions` block to the `publish` job. This block will limit the permissions of the `GITHUB_TOKEN` to only what is necessary for the job. Based on the workflow's functionality, the `publish` job primarily interacts with crates.io and does not require write access to the repository contents. Therefore, we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
