### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/peanutbother/serini/security/code-scanning/1](https://github.com/peanutbother/serini/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `test` job. Since the job only involves testing and formatting, it likely only requires `contents: read` permissions. This change ensures that the job adheres to the principle of least privilege and avoids inheriting unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
